### PR TITLE
fix: CRAN packages not using the correct compiler in configure scripts #17

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -28,9 +28,9 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -44,7 +44,7 @@ jobs:
             rcmdcheck
             roxygen2
           working-directory: ./Rmixmod
-            
+
       - name: Create directory
         run: |
           mkdir -p Rmixmod_build/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install
       run: |
         sudo apt install -y cmake libeigen3-dev libxml++2.6-dev

--- a/Rmixmod/DESCRIPTION
+++ b/Rmixmod/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rmixmod
-Version: 2.1.7
-Date: 2022-10-18
+Version: 2.1.8
+Date: 2023-01-17
 Title: Classification with Mixture Modelling
 Description: Interface of 'MIXMOD' software for supervised, unsupervised and
     semi-supervised classification with mixture modelling <doi: 10.18637/jss.v067.i06>.

--- a/Rmixmod/configure.ac
+++ b/Rmixmod/configure.ac
@@ -1,6 +1,25 @@
-#https://nerdland.net/2009/07/detecting-c-libraries-with-autotools/
-AC_INIT([Rmixmod],[2.1.4])
+# https://nerdland.net/2009/07/detecting-c-libraries-with-autotools/
+AC_INIT([Rmixmod],[2.1.8])
+
+# https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Configure-and-cleanup
+# Find the compiler and compiler flags used by R.
+: ${R_HOME=`R RHOME`}
+if test -z "${R_HOME}"; then
+  echo "could not determine R_HOME"
+  exit 1
+fi
+
+# pick up the details for the C++ compiler and switch the current language to C++
+CXX=`"${R_HOME}/bin/R" CMD config CXX`
+if test -z "$CXX"; then
+  AC_MSG_ERROR([No C++ compiler is available])
+fi
+CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXXFLAGS`
+CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
+AC_LANG(C++)
+
 AC_PATH_PROG([PKG_CONFIG], [pkg-config])
+
 if test "${RMIXMOD_WITH_XML}" = "1"  ; then
 	if test -z "${PKG_CONFIG}"; then
 		AC_MSG_WARN([cannot find pkg-config, Rmixmod will be installed without optional XML features])


### PR DESCRIPTION
closes #17