### PR TITLE
Cmake: Bump cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Configuration
 #--------------
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type")
 PROJECT(mixmod)
 

--- a/mixmodGUI/CMakeLists.txt
+++ b/mixmodGUI/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Configuration
 #--------------
-cmake_minimum_required(VERSION 2.8.5)
+cmake_minimum_required(VERSION 3.5)
 project(mixmodGUI)
 #include(${CMAKE_SOURCE_DIR}/../../../../cmake_shared_config.txt)
 

--- a/mixmodMVC/CMakeLists.txt
+++ b/mixmodMVC/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Configuration
 #--------------
-cmake_minimum_required(VERSION 2.8.5)
+cmake_minimum_required(VERSION 3.5)
 project(mixmodmvc)
 
 # Installation prefix, packaging prefix


### PR DESCRIPTION
Bump cmake version to 3.5 to avoid this deprecation message:

```
CMake Deprecation Warning at CMakeLists.txt:15 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```