### PR TITLE
ModelOutput: Add accessor to completed likelihood

### DIFF
--- a/mixmodLib/SRC/mixmod/Kernel/IO/ModelOutput.cpp
+++ b/mixmodLib/SRC/mixmod/Kernel/IO/ModelOutput.cpp
@@ -68,6 +68,9 @@ ModelOutput::ModelOutput(Model * estimation) {
 	}
 
 	_likelihood = estimation->getLogLikelihood(false);
+
+        if (estimation->getAlgoName() != UNKNOWN_ALGO_NAME)
+          _completedLikelihood = estimation->getCompletedLogLikelihood();
 }
 
 //------------------------------
@@ -114,7 +117,6 @@ ModelOutput::ModelOutput(ModelType & modelType, int64_t nbCluster, Exception& er
 	_probaDescription = NULL;
 	_labelDescription = NULL;
 	_parameterDescription = NULL;
-	_likelihood = 0;
 }
 
 //-----------

--- a/mixmodLib/SRC/mixmod/Kernel/IO/ModelOutput.h
+++ b/mixmodLib/SRC/mixmod/Kernel/IO/ModelOutput.h
@@ -91,6 +91,7 @@ public:
 	Model * getModel() const;
 
 	double getLikelihood() const;
+	double getCompletedLikelihood() const;
 
 	CriterionOutput const & getCriterionOutput(CriterionName criterionName) const;
 	CriterionOutput const & getCriterionOutput(const int index) const;
@@ -119,8 +120,11 @@ protected:
 	// the probabilities of the model
 	ProbaDescription * _probaDescription;
 
-	// the model likelihood
-	double _likelihood;
+	// the model log-likelihood
+	double _likelihood = 0.0;
+
+        // the penalized log-likelihood
+	double _completedLikelihood = 0.0;
 
 	// the error
 	Exception * _strategyRunError;
@@ -152,6 +156,10 @@ inline Exception & ModelOutput::getStrategyRunError() const {
 
 inline double ModelOutput::getLikelihood() const {
 	return _likelihood;
+}
+
+inline double ModelOutput::getCompletedLikelihood() const {
+	return _completedLikelihood;
 }
 
 inline CriterionOutput const & ModelOutput::getCriterionOutput(CriterionName criterionName) const {


### PR DESCRIPTION
This allows to select the right number of clusters without overfitting